### PR TITLE
fix install instructions for rnaturalearthhires

### DIFF
--- a/R/install-rnaturalearthhires.r
+++ b/R/install-rnaturalearthhires.r
@@ -19,8 +19,7 @@ check_rnaturalearthhires <- function() {
 install_rnaturalearthhires <- function() {
   instructions <- paste(" Please try installing the package for yourself",
                         "using the following command: \n",
-                        "    install.packages(\"rnaturalearthhires\", repos = \"http://packages.ropensci.org\",",
-                        "type = \"source\")")
+                        "    devtools::install_github(\"ropensci/rnaturalearthhires\")")
   
   error_func <- function(e) {
     stop(paste("Failed to install the rnaturalearthhires package.\n", instructions))

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,9 +60,7 @@ Data to support much of the package functionality are stored in two data package
 
 ```
 devtools::install_github("ropensci/rnaturalearthdata")
-install.packages("rnaturalearthhires",
-                 repos = "http://packages.ropensci.org",
-                 type = "source")
+devtools::install_github("ropensci/rnaturalearthhires")
 ```
 
 ### First Usage


### PR DESCRIPTION
Implementing changes suggested in https://github.com/ropensci/rnaturalearthhires/issues/1 and https://github.com/ropensci/rnaturalearthhires/issues/2 to provide installation instructions for `rnaturalearthhires` that work.

It might also be useful to similarly update the automatic installation procedure (below), but that change should probably be made by someone more familiar with these packages.
https://github.com/ropensci/rnaturalearth/blob/543e3cbc2c913724ed66e742f0b8c38828ef1002/R/install-rnaturalearthhires.r#L29-L46