### PR TITLE
Directory issue for rasters

### DIFF
--- a/R/ne_download.r
+++ b/R/ne_download.r
@@ -117,7 +117,7 @@ ne_download <- function(scale = 110,
   if ( load & category == 'raster' )
   {
     # have to use file_name to set the folder and the tif name
-    rst <- raster::raster(file.path(destdir, file_name, paste0(file_name, '.tif')))
+    rst <- raster::raster(file.path(destdir, paste0(file_name, '.tif')))
     return(rst)
     
     


### PR DESCRIPTION
ne_download() downloads the raster properly and unzips, but when reading in the file, the path adds an extra file name. 

This pull request deletes the file name. It runs properly on my test code:


require(tidyverse)
library(rnaturalearth)
require(stars)
require(sf)

background_orig <- ne_download(scale = 10, type = 'HYP_LR_SR_W_DR', category = 'raster')

bb = st_bbox(c(xmin = -115, ymin = 25, xmax = -100, ymax = 50), crs = st_crs(background_orig))
background <- st_as_stars(background_orig, proxy= FALSE) %>% st_crop(bb) %>%st_rgb(3)

plot(background)
