### PR TITLE
Use lifecycle to warn user of the eventual drop of support for the  sp package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,9 @@ Suggests:
     dplyr,
     purrr,
     rmarkdown,
-    tmap
+    tmap,
+    lifecycle (>= 1.0.3),
+    rlang
 Config/Needs/website:  ropensci/rnaturalearthhires
 VignetteBuilder: knitr
 RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rnaturalearth (development version)
 
+- Using `lifecycle` to indicate that support of `sp` object will be eventually droped. Users should now use `ne_download(returnclass = "sf")`, instead of `ne_download(returnclass = "sp")`.
 - `terra` is now included in the Imports section.
 
 # rnaturalearth 0.3.2

--- a/R/deprecate_sp.R
+++ b/R/deprecate_sp.R
@@ -1,0 +1,28 @@
+rnaturalearth_env <- new.env(parent = emptyenv())
+
+.onLoad <- function(...) {
+  assign("rnaturalearth_update_message", FALSE, envir = rnaturalearth_env)
+}
+
+rnaturalearthStartupMessage <- function() {
+  msg <- "Support for Spatial objects (`sp`) will be deprecated in {rnaturalearth} and will be removed in a future release of the package. Please use `sf` objects with {rnaturalearth}. For example: `ne_download(returnclass = 'sf')`"
+}
+
+.onAttach <- function(lib, pkg) {
+  # startup message
+  msg <- rnaturalearthStartupMessage()
+  packageStartupMessage(msg)
+  invisible()
+}
+
+deprecate_sp <- function(what,
+                         env = rlang::caller_env(),
+                         user_env = rlang::caller_env(2)) {
+  lifecycle::deprecate_warn(
+    when = "1.0.0",
+    what = what,
+    details = "Please use `sf` objects with {rnaturalearth}, support for Spatial objects (sp) will be removed in a future release of the package.",
+    env = env,
+    user_env = user_env
+  )
+}

--- a/R/ne_coastline.R
+++ b/R/ne_coastline.R
@@ -23,6 +23,10 @@ ne_coastline <- function(scale = 110,
                          returnclass = c("sp", "sf")) {
   returnclass <- match.arg(returnclass)
 
+  if (returnclass == "sp") {
+    deprecate_sp("ne_download(returnclass = 'sp')")
+  }
+
   # check for the data packages and try to install if not there
   if (scale == 10) {
     check_rnaturalearthhires()

--- a/R/ne_countries.R
+++ b/R/ne_countries.R
@@ -56,6 +56,10 @@ ne_countries <- function(scale = 110,
                          returnclass = c("sp", "sf")) {
   returnclass <- match.arg(returnclass)
 
+  if (returnclass == "sp") {
+    deprecate_sp("ne_download(returnclass = 'sp')")
+  }
+
   spdf <- get_data(scale = scale, type = type)
 
   # some large scale NE data still have old uppercase fieldnames, this to

--- a/R/ne_download.R
+++ b/R/ne_download.R
@@ -95,6 +95,10 @@ ne_download <- function(scale = 110,
   category <- match.arg(category)
   returnclass <- match.arg(returnclass)
 
+  if (returnclass == "sp") {
+    deprecate_sp("ne_download(returnclass = 'sp')")
+  }
+
   # without extension, e.g. .shp
   file_name <- ne_file_name(
     scale = scale, type = type, category = category, full_url = FALSE

--- a/R/ne_load.R
+++ b/R/ne_load.R
@@ -57,7 +57,12 @@ ne_load <- function(scale = 110,
                     file_name = NULL,
                     returnclass = c("sp", "sf")) {
   category <- match.arg(category)
+
   returnclass <- match.arg(returnclass)
+
+  if (returnclass == "sp") {
+    deprecate_sp("ne_download(returnclass = 'sp')")
+  }
 
   if (is.null(file_name)) {
     file_name <- ne_file_name(scale = scale, type = type, category = category)

--- a/R/ne_states.R
+++ b/R/ne_states.R
@@ -40,6 +40,10 @@ ne_states <- function(country = NULL,
                       returnclass = c("sp", "sf")) {
   returnclass <- match.arg(returnclass)
 
+  if (returnclass == "sp") {
+    deprecate_sp("ne_download(returnclass = 'sp')")
+  }
+
   # set map from one stored this adds potential to add or pass other potential
   # state maps, e.g. without lakes but no checking is done, may not be needed
   if (is.null(spdf)) {


### PR DESCRIPTION
@andysouth @khufkens This could be a small release warning users for the eventual drop of the `sp` package since it is no longer maintained.

Great information in this thread and associated blog post: https://twitter.com/jakub_nowosad/status/1665358051145052161