### PR TITLE
replace devtools with pak for package installation to reduce dependencies

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,12 +33,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          pak-version: "devel"
+          extra-packages: any::pkgdown, ropensci-org/rotemplate, local::.
           needs: website
-
-      - name: Install dependencies
-        run: devtools::install_github("https://github.com/ropensci-org/rotemplate")
-        shell: Rscript {0}
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     terra,
     utils (>= 3.2.3)
 Suggests:
-    devtools (>= 1.10.0),
+    pak,
     dplyr,
     ggplot2,
     ggrepel,
@@ -56,4 +56,4 @@ Suggests:
     tmap
 Config/Needs/website: ropensci/rnaturalearthhires
 VignetteBuilder: knitr
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rnaturalearth (development version)
 
+- Replaced `devtools` with `pak` for installing companion packages `rnaturalearthdata` and `rnaturalearthhires` from GitHub, reducing dependencies.
+
 # rnaturalearth 1.1.0
 
 ## New features

--- a/R/install-rnaturalearthdata.R
+++ b/R/install-rnaturalearthdata.R
@@ -1,7 +1,7 @@
 #' Check whether to install rnaturalearthdata and install if necessary
 #'
 #' If the rnaturalearthdata package is not installed, install it from GitHub
-#' using devtools. If it is not up to date, reinstall it.
+#' using pak. If it is not up to date, reinstall it.
 #'
 #' @export
 check_rnaturalearthdata <- function() {

--- a/R/install-rnaturalearthhires.R
+++ b/R/install-rnaturalearthhires.R
@@ -1,7 +1,7 @@
 #' Check whether to install rnaturalearthhires and install if necessary
 #'
 #' If the rnaturalearthhires package is not installed, install it from GitHub
-#' using devtools. If it is not up to date, reinstall it.
+#' using pak. If it is not up to date, reinstall it.
 #'
 #' @export
 check_rnaturalearthhires <- function() {
@@ -37,14 +37,14 @@ install_rnaturalearthhires <- function() {
 
   if (input != 1L) {
     cli::cli_abort(
-      "The {.pkg rnaturalearthhires} package is necessary for that method.\n Please try installing the package yourself with {.code devtools::install_github(\"ropensci/rnaturalearthhires\")}"
+      "The {.pkg rnaturalearthhires} package is necessary for that method.\n Please try installing the package yourself with {.code pak::pkg_install(\"ropensci/rnaturalearthhires\")}"
     )
   }
 
   cli::cli_inform("Installing the {.pkg rnaturalearthhires} package.")
 
   tryCatch(
-    devtools::install_github("ropensci/rnaturalearthhires"),
+    pak::pkg_install("ropensci/rnaturalearthhires"),
     error = function(e) {
       cli::cli_inform(conditionMessage(e))
     }

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,17 +53,17 @@ Install from CRAN :
 install.packages("rnaturalearth")
 ```
 
-or install the development version from GitHub using [devtools](https://github.com/r-lib/devtools).
+or install the development version from GitHub using [pak](https://github.com/r-lib/pak/).
 
 ```r
-devtools::install_github("ropensci/rnaturalearth")
+pak::pkg_install("ropensci/rnaturalearth")
 ```
 
 Data to support much of the package functionality are stored in two data packages that you will be prompted to install when required if you do not do so here.
 
 ```r
-devtools::install_github("ropensci/rnaturalearthdata")
-devtools::install_github("ropensci/rnaturalearthhires")
+pak::pkg_install("ropensci/rnaturalearthdata")
+pak::pkg_install("ropensci/rnaturalearthhires")
 ```
 
 ## First usage
@@ -165,7 +165,6 @@ Thanks to [Lincoln Mullen](https://github.com/lmullen) for code structure inspir
 ### Potential additional functions
 
 - facilitate joining of user data to country boundaries
-
   - similar to https://github.com/AndySouth/rworldmap/blob/master/R/joinCountryData2Map.R
   - ... but with a better name
   - similar allowing of join by ISO codes or names, with attempted synonym matching

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ install.packages("rnaturalearth")
 ```
 
 or install the development version from GitHub using
-[devtools](https://github.com/r-lib/devtools).
+[pak](https://github.com/r-lib/pak/).
 
 ``` r
-devtools::install_github("ropensci/rnaturalearth")
+pak::pkg_install("ropensci/rnaturalearth")
 ```
 
 Data to support much of the package functionality are stored in two data
@@ -64,8 +64,8 @@ packages that you will be prompted to install when required if you do
 not do so here.
 
 ``` r
-devtools::install_github("ropensci/rnaturalearthdata")
-devtools::install_github("ropensci/rnaturalearthhires")
+pak::pkg_install("ropensci/rnaturalearthdata")
+pak::pkg_install("ropensci/rnaturalearthhires")
 ```
 
 ## First usage
@@ -198,14 +198,11 @@ resource.
 ### Potential additional functions
 
 - facilitate joining of user data to country boundaries
-
   - similar to
     <https://github.com/AndySouth/rworldmap/blob/master/R/joinCountryData2Map.R>
   - … but with a better name
   - similar allowing of join by ISO codes or names, with attempted
     synonym matching
   - similar reporting of country joining success and failure
-
 - facilitate subsetting by country groupings
-
   - e.g. least developed countries etc.

--- a/man/check_rnaturalearthdata.Rd
+++ b/man/check_rnaturalearthdata.Rd
@@ -8,5 +8,5 @@ check_rnaturalearthdata()
 }
 \description{
 If the rnaturalearthdata package is not installed, install it from GitHub
-using devtools. If it is not up to date, reinstall it.
+using pak. If it is not up to date, reinstall it.
 }

--- a/man/check_rnaturalearthhires.Rd
+++ b/man/check_rnaturalearthhires.Rd
@@ -8,5 +8,5 @@ check_rnaturalearthhires()
 }
 \description{
 If the rnaturalearthhires package is not installed, install it from GitHub
-using devtools. If it is not up to date, reinstall it.
+using pak. If it is not up to date, reinstall it.
 }

--- a/rnaturalearth.Rproj
+++ b/rnaturalearth.Rproj
@@ -13,6 +13,6 @@ RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
 BuildType: Package
-PackageUseDevtools: Yes
+PackageUseDevtools: No
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Use `pak` instead of `devtools` to install `rnaturalearthhires` (use less dependencies).